### PR TITLE
Icons and logo width resolve

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -367,6 +367,10 @@ z-index: 1;
   }
 }
 
+h1 img {
+  width: 80%;
+}
+
 h2.home-page-title {
 font-family: 'Dosis', sans-serif;
 font-style: normal;

--- a/css/style.css
+++ b/css/style.css
@@ -1796,7 +1796,7 @@ bottom: 17px;
 }
 
 .social-icons-wrapper.social-icons-wrapper-mobile {
-visibility: hidden;
+visibility: hidden !important;
 }
 
 @media only screen and (max-width: 640px) {

--- a/index.html
+++ b/index.html
@@ -13,7 +13,13 @@
         <!-- Waye v1.0 || ex nihilo || January 2018 -->
         <!-- style start -->
         <link href="css/plugins.css" media="all" rel="stylesheet" type="text/css">
-        <link href="css/style.css" media="all" rel="stylesheet" type="text/css"><!-- style end -->
+        <link href="css/style.css" media="all" rel="stylesheet" type="text/css">
+        <!-- style end -->
+        
+        <!-- icons -->
+        <link href="https://unpkg.com/ionicons@4.5.10-0/dist/css/ionicons.min.css" rel="stylesheet"/>
+        <!-- icons end -->
+
         <!-- google fonts start -->
         <link href="https://fonts.googleapis.com/css?family=Raleway:100,200,300,400,500,600,700,800,900%7CDosis:200,300,400,500,600,700,800%7COswald:300,400,700" rel="stylesheet" type="text/css">
         <!-- google fonts end -->


### PR DESCRIPTION
- Before the "responsive logo" commit, the logo surpassed the mobile screen width.
- Before the "resolve icons" commit, the social icons were shown and the to-top icon was a undefined icon rectangle.